### PR TITLE
Switched eject with getout to fix the bug with helicopters

### DIFF
--- a/FAR_revive_funcs.sqf
+++ b/FAR_revive_funcs.sqf
@@ -64,7 +64,7 @@ FAR_Player_Unconscious =
 	if (vehicle _unit != _unit) then
 	{
 		unAssignVehicle _unit;
-		_unit action ["eject", vehicle _unit];
+		_unit action ["getOut", vehicle _unit];
 		
 		sleep 2;
 	};


### PR DESCRIPTION
I fixed the bug with helicopters that would freeze the game if players couldn't eject from the vehicle
